### PR TITLE
Fixes for WAF lab

### DIFF
--- a/WAF/docker-dvwa-modsecurity/Dockerfile
+++ b/WAF/docker-dvwa-modsecurity/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.2
+FROM debian:10.2
 
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -20,7 +20,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY php.ini /etc/php5/apache2/php.ini
+COPY php.ini /etc/php/7.3/apache2/php.ini
 COPY dvwa /var/www/html
 
 COPY config.inc.php /var/www/html/config/

--- a/WAF/docker-dvwa-modsecurity/php.ini
+++ b/WAF/docker-dvwa-modsecurity/php.ini
@@ -41,7 +41,7 @@ file_uploads = On
 upload_max_filesize = 2M
 max_file_uploads = 20
 allow_url_fopen = On
-allow_url_include = 1
+allow_url_include = On
 default_socket_timeout = 60
 [CLI Server]
 cli_server.color = On

--- a/WAF/exploitation.py
+++ b/WAF/exploitation.py
@@ -9,7 +9,7 @@ def send_request(ip, route, data, cookies, method):
                           cookies=cookies,
                           data=data)
     else:
-        r = requests.get(f"http://{ip}/{route}/",
+        r = requests.get(f"http://{ip}/vulnerabilities/{route}/",
                          cookies=cookies,
                          params=data)
     if r.status_code == 403:


### PR DESCRIPTION
Немножко фиксов для лабы по WAF, чтобы она сразу запускалась и нормально работала:

1. бамп версии образа `debian`
2. соответствующие фиксы в конфигурации PHP
3. фикс в чекере: без него он получает 404 ошибку на всех GET-запросах, в результате чего говорит что сервис уязвим, даже если правила в вафе уже применены. Пример:

![image](https://github.com/Ivanhahanov/InformationSecurityMethodsAndTools/assets/34795180/0c5e1415-1afe-4624-bfe6-2315dedc429f)
